### PR TITLE
Add passthrough functions to VRWindow

### DIFF
--- a/Modules/VRWrapper/RNVRWindow.h
+++ b/Modules/VRWrapper/RNVRWindow.h
@@ -61,6 +61,9 @@ namespace RN
 		RNVRAPI virtual void StopRendering() = 0;
 		RNVRAPI virtual bool IsRendering() const = 0;
 
+		RNVRAPI virtual bool InitializePassthrough(bool startRunning);
+		RNVRAPI virtual void SetPassthroughActive(bool active);
+
 		RNVRAPI virtual void SetTitle(const String *title) override {}
 		RNVRAPI virtual Screen *GetScreen() override { return nullptr; }
 


### PR DESCRIPTION
Implemented only for OpenXR, but final keyword isn't accepted without virtual declaration