### PR TITLE
Jolt: fix Compound shapes not initializing their _shape

### DIFF
--- a/Modules/Jolt/RNJoltShape.cpp
+++ b/Modules/Jolt/RNJoltShape.cpp
@@ -211,6 +211,8 @@ namespace RN
 
 	JoltCompoundShape::JoltCompoundShape()
 	{
+		_shape = new JPH::MutableCompoundShape();
+		_shape->AddRef();
 	}
 
 	JoltCompoundShape::JoltCompoundShape(Model *model, JoltMaterial *material, Vector3 scale, bool useTriangleMesh, bool wantsDoubleSided)
@@ -229,6 +231,9 @@ namespace RN
 
 	JoltCompoundShape::JoltCompoundShape(const Array *meshes, JoltMaterial *material, Vector3 scale, bool useTriangleMesh, bool wantsDoubleSided)
 	{
+		_shape = new JPH::MutableCompoundShape();
+		_shape->AddRef();
+
 		meshes->Enumerate<Mesh>([&](Mesh *mesh, size_t index, bool &stop) {
 			AddChild(mesh, material, Vector3(), Quaternion(), scale, useTriangleMesh, wantsDoubleSided);
 		});

--- a/Modules/Jolt/RNJoltShape.h
+++ b/Modules/Jolt/RNJoltShape.h
@@ -107,16 +107,12 @@ namespace RN
 		JTAPI void AddChild(JoltShape *shape, const RN::Vector3 &position, const RN::Quaternion &rotation);
 
 		JoltShape *GetShape(size_t index) const { return _shapes[index]; }
-		RN::Vector3 GetPosition(size_t index) const { return _positions[index]; }
-		RN::Quaternion GetRotation(size_t index) const { return _rotations[index]; }
 		size_t GetNumberOfShapes() const { return _shapes.size(); }
 
 		JTAPI static JoltCompoundShape *WithModel(Model *model, JoltMaterial *material, Vector3 scale, bool useTriangleMesh, bool wantsDoubleSided = false);
 
 	private:
 		std::vector<JoltShape *> _shapes;
-		std::vector<RN::Vector3> _positions;
-		std::vector<RN::Quaternion> _rotations;
 
 		RNDeclareMetaAPI(JoltCompoundShape, JTAPI)
 	};


### PR DESCRIPTION
Need to look into this further to be sure, but pretty sure `JoltCompoundShape` would simply not initialize a `_shape`.
Maybe just adding the super constructor would also fix it.